### PR TITLE
missing % for M (minute) in datetime format string

### DIFF
--- a/src/rdf_term.ml
+++ b/src/rdf_term.ml
@@ -56,7 +56,7 @@ let term_of_literal_string ?typ ?lang v =
 
 let now () = CalendarLib.Fcalendar.now()
 let mk_literal_datetime ?(d=now()) () =
-  let v = CalendarLib.Printer.Fcalendar.sprint "%Y-%m-%dT%H:M:%S%:z" d in
+  let v = CalendarLib.Printer.Fcalendar.sprint "%Y-%m-%dT%H:%M:%S%:z" d in
   mk_literal ~typ: (Iri.of_string "http://www.w3.org/2001/XMLSchema#dateTime") v
 ;;
 
@@ -64,7 +64,7 @@ let term_of_datetime ?d () =
   Literal (mk_literal_datetime ?d ())
 ;;
 
-let fmt = "%Y-%m-%dT%H:M:%S"
+let fmt = "%Y-%m-%dT%H:%M:%S"
 let fmt_tz = fmt^"%:z"
 let fmt_utc = fmt^"Z"
 


### PR DESCRIPTION
Minutes of datetimes weren't properly formatted in output.